### PR TITLE
fix print to able easy copy-paste with double click

### DIFF
--- a/cmd/jenkins-credentials-decryptor/main.go
+++ b/cmd/jenkins-credentials-decryptor/main.go
@@ -41,7 +41,7 @@ func print(decryptedCredentials []xml.Credential) {
 	for i, credential := range decryptedCredentials {
 		fmt.Println(i)
 		for k, v := range credential.Tags {
-			fmt.Printf("\t%s=%s\n", k, v)
+			fmt.Printf("\t%s: %s\n", k, v)
 		}
 	}
 }


### PR DESCRIPTION
We are just moving old jenkins to kubernetes one, and the story was about this commit is:
_that was a pain in the ass copying the strings with cursor-precise moves._
So this modification helped to increase this robotic job efficiency by decreasing the time it needs.

And it's prettier now :sunglasses: 